### PR TITLE
periodic/antiperiodic option for spectral projectors

### DIFF
--- a/projects/generate_confs/parser.ypp
+++ b/projects/generate_confs/parser.ypp
@@ -260,6 +260,8 @@
 //spectral proj meas
 %type <spectr_proj_meas> spectr_proj_meas
 %token TK_SPECTR_PROJ
+%type <int_numb> is_antiperiodic
+%token TK_IS_ANTIPERIODIC
 %token TK_NEIGS
 %type <int_numb> neigs
 %token TK_EIG_PRECISION
@@ -396,6 +398,8 @@ noise_type: TK_NOISE_TYPE '=' TK_RND_T {$$=$3;};
 compute_susc: TK_COMPUTE_SUSC '=' int_numb {$$=$3;};
 
 neigs: TK_NEIGS '=' int_numb {$$=$3;};
+
+is_antiperiodic: TK_IS_ANTIPERIODIC '=' int_numb {$$=$3;};
 
 eig_precision: TK_EIG_PRECISION '=' double_numb {$$=$3;};
 
@@ -753,6 +757,7 @@ spectr_proj_meas: TK_SPECTR_PROJ {$$=new spectr_proj_meas_pars_t();}
                 | spectr_proj_meas ncopies {$$->ncopies=$2;}
                 | spectr_proj_meas noise_type {$$->rnd_type=$2;}
                 | spectr_proj_meas nhits {$$->nhits=$2;}
+                | spectr_proj_meas is_antiperiodic {$$->is_antiperiodic=$2;}
                 | spectr_proj_meas neigs {$$->neigs=$2;}
                 | spectr_proj_meas eig_precision {$$->eig_precision=$2;}
                 | spectr_proj_meas wspace_size {$$->wspace_size=$2;}

--- a/projects/generate_confs/tokenizer.lpp
+++ b/projects/generate_confs/tokenizer.lpp
@@ -262,6 +262,7 @@ ComputeSusc DEBUG_PRINTF("Found ComputeSusc\n");return TK_COMPUTE_SUSC;
 
  /* parameters for SpectrProj */
 Neigs DEBUG_PRINTF("Found Neigs\n");return TK_NEIGS;
+IsAntiperiodic DEBUG_PRINTF("Found IsAntiperiodic\n");return TK_IS_ANTIPERIODIC;
 EigPrecision DEBUG_PRINTF("Found EigPrecision\n");return TK_EIG_PRECISION;
 
  /* parameters for MinmaxEigenvalues */

--- a/src/hmc/backfield.hpp
+++ b/src/hmc/backfield.hpp
@@ -67,6 +67,7 @@ namespace nissa
   {add_or_rem_backfield_with_or_without_stagphases_to_conf(conf,1,u1,1);}
   
   void init_backfield_to_id(quad_u1 **S);
+  void add_antiperiodic_condition_to_backfield(quad_u1 **S, int mu);
   void add_im_pot_to_backfield(quad_u1 **S,quark_content_t *quark_content);
   void add_em_field_to_backfield(quad_u1 **S,quark_content_t *quark_content,double em_str,int q,int mu,int nu);
   void add_em_field_to_backfield(quad_u1 **S,quark_content_t *quark_content,em_field_pars_t &em_field_pars);

--- a/src/measures/fermions/spectral_projectors.cpp
+++ b/src/measures/fermions/spectral_projectors.cpp
@@ -30,6 +30,7 @@ namespace nissa
     //identity backfield
     quad_u1 *u1b[2]={nissa_malloc("u1b",loc_volh+bord_volh,quad_u1),nissa_malloc("u1b",loc_volh+bord_volh,quad_u1)};
     init_backfield_to_id(u1b);
+    add_antiperiodic_condition_to_backfield(u1b,0);
     
     //temporary vectors
     color *tmpvec_eo[2]={nissa_malloc("tmpvec_eo_EVN",loc_volh+bord_volh,color),nissa_malloc("tmpvec_eo_ODD",loc_volh+bord_volh,color)};

--- a/src/measures/fermions/spectral_projectors.hpp
+++ b/src/measures/fermions/spectral_projectors.hpp
@@ -12,12 +12,14 @@ namespace nissa
   //parameters to measure topology properties
   struct spectr_proj_meas_pars_t : base_fermionic_meas_t
   {
+    int is_antiperiodic;
     int neigs;            //number of eigenvalues required
     double eig_precision; //relative precision between eigenvalues
     int wspace_size;      //size of Krylov space for the Arnoldi algorithm (it would be clipped in [2*neigs,mat_size])
     smooth_pars_t smooth_pars;
 
     std::string def_path(){return "pettirosso";}
+    int def_is_antiperiodic(){return 1;}
     int def_neigs(){return 5;}
     double def_eig_precision(){return 1e-5;}
     int def_wspace_size(){return DEFAULT_EIGPROB_WSPACE_SIZE;}
@@ -30,6 +32,7 @@ namespace nissa
       return
 	base_fermionic_meas_t::is_nonstandard() or
 	path!=def_path() or
+	is_antiperiodic!=def_is_antiperiodic() or
 	neigs!=def_neigs() or
 	eig_precision!=def_eig_precision() or
 	wspace_size!=def_wspace_size() or
@@ -38,6 +41,7 @@ namespace nissa
     
     spectr_proj_meas_pars_t() :
       base_fermionic_meas_t(),
+      is_antiperiodic(def_is_antiperiodic()),
       neigs(def_neigs()),
       eig_precision(def_eig_precision()),
       wspace_size(def_wspace_size())


### PR DESCRIPTION
A new token has been defined -> call as spectral projector option as:
'IsAntiperiodic = 1' for antiperiodic bc (default), or
'IsAntiperiodic = 0' for periodic bc