### PR TITLE
changed taste structure from g5xg5 to g5xid

### DIFF
--- a/src/measures/fermions/ellesettete.cpp
+++ b/src/measures/fermions/ellesettete.cpp
@@ -116,12 +116,12 @@ namespace nissa
 		    SUMM_THE_TIME_TRACE_PRINT_AT_LAST_HIT(Tr_four_pts,SEQ_PROP,SEQ_PROP);
 
 		    //////// disconnected ////////
-		    apply_stag_op(source_g5,conf,theory_pars.backfield[iflav],GAMMA_INT::GAMMA_5,GAMMA_INT::GAMMA_5,source);
+		    apply_stag_op(source_g5_id,conf,theory_pars.backfield[iflav],GAMMA_INT::GAMMA_5,GAMMA_INT::IDENTITY,source);
 			
 		    if(ihit==meas_pars.nhits-1) master_fprintf(file," # Tr_no_insertion_bubble source time %d\n", glb_t);
-		    SUMM_THE_TRACE_PRINT_AT_LAST_HIT(Tr_no_insertion_bubble,SIMPLE_PROP,source_g5);
+		    SUMM_THE_TRACE_PRINT_AT_LAST_HIT(Tr_no_insertion_bubble,SIMPLE_PROP,source_g5_id);
 		    if(ihit==meas_pars.nhits-1) master_fprintf(file,"\n # Tr_insertion_bubble source time %d\n", glb_t);
-		    SUMM_THE_TRACE_PRINT_AT_LAST_HIT(Tr_insertion_bubble,SEQ_PROP,source_g5);
+		    SUMM_THE_TRACE_PRINT_AT_LAST_HIT(Tr_insertion_bubble,SEQ_PROP,source_g5_id);
 		    master_fprintf(file,"\n");
 		  }
 		  master_fprintf(file,"\n");
@@ -135,7 +135,7 @@ namespace nissa
     DELETE_FIELD_T(SIMPLE_PROP);
     DELETE_FIELD_T(SEQ_PROP);
     DELETE_FIELD_T(source);
-    DELETE_FIELD_T(source_g5);
+    DELETE_FIELD_T(source_g5_id);
     nissa_free(point_result);
 	close_file(file);
   }

--- a/src/measures/fermions/ellesettete.cpp
+++ b/src/measures/fermions/ellesettete.cpp
@@ -44,7 +44,7 @@
 	So the diagram should be prod of one "normal" φ and the sequential Φ*
 
 	one-end trick autmatically project to 0 momentum 
-	test-git
+	
 */
 
 

--- a/src/measures/fermions/ellesettete.cpp
+++ b/src/measures/fermions/ellesettete.cpp
@@ -44,7 +44,7 @@
 	So the diagram should be prod of one "normal" φ and the sequential Φ*
 
 	one-end trick autmatically project to 0 momentum 
-
+	test-git
 */
 
 


### PR DESCRIPTION
_atm I've changed just the source that enters in the bubbles for the disconnected diagrams, since they are the only one that keep a g5 explicitly_

If we compute the contributions for the connected diagrams (2,3,4pts) in the continuum, at the end we will be left with just contractions of G, G^dag thanks to g5-hermiticity.
Then going to the staggered world. g5 ----> g5 x I,P,T,A,V and at priori all of the structure in taste are good, but:
1) if we want to preserve the contraction in the connected diagrams, as they are, then we shall use g5 x P = g5 x g5, which is indeed the one that implement the g5-hermiticity ,
2) if we want the 2pt conn function to reproduce C_iso we know again that the good GB is given by  g5 x g5,
3) in the disc diagrams g5 is left explicit and we didn't exploit any g5-hermiticty for the contractions.

Since in the disc diagrams g5 x g5 didn't give any positive results, I would say to use g5 x id just here, as if we're exploring a different taste structure among all the others which are at priori all good...
makes sense?

